### PR TITLE
update for opendnp3 version 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 2.8)
 project (dnp3cgi)
-set(DNP3CGI_MAJOR_VERSION 2)
+set(DNP3CGI_MAJOR_VERSION 3)
 set(DNP3CGI_MINOR_VERSION 1)
 set(DNP3CGI_MICRO_VERSION 0)
 set(DNP3CGI_VERSION ${DNP3CGI_MAJOR_VERSION}.${DNP3CGI_MINOR_VERSION}.${DNP3CGI_MICRO_VERSION})
@@ -15,6 +15,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
   
 # ---- decoder exe
 file(GLOB_RECURSE dnp3cgi_SRC ./src/*.cpp)
-add_executable(dnp3cgi ${dnp3cgi_SRC} src/DecodeHandler.h)
-target_link_libraries (dnp3cgi dnp3decode opendnp3 openpal cgicc)
+add_executable(dnp3cgi ${dnp3cgi_SRC})
+target_link_libraries (dnp3cgi opendnp3 cgicc)
 

--- a/src/DecodeHandler.cpp
+++ b/src/DecodeHandler.cpp
@@ -1,11 +1,10 @@
 
 #include "DecodeHandler.h"
 
-#include <opendnp3/LogLevels.h>
+#include <opendnp3/logging/LogLevels.h>
 #include <iostream>
 
 using namespace std;
-using namespace openpal;
 using namespace opendnp3;
 
 DecodeHandler::DecodeHandler() : indent(0)
@@ -13,11 +12,11 @@ DecodeHandler::DecodeHandler() : indent(0)
 
 }
 
-void DecodeHandler::Log( const LogEntry& entry )
+void DecodeHandler::log(ModuleId module, const char* id, LogLevel level, char const* location, char const* message)
 {
-    auto clazz = GetClass(entry.filters);
-    cout << "<pre class=\"" << GetClass(entry.filters) << " indent" << indent << "\">" << std::endl;
-    cout << entry.message << std::endl;
+    auto clazz = GetClass(level);
+    cout << "<pre class=\"" << GetClass(level) << " indent" << indent << "\">" << std::endl;
+    cout << message << std::endl;
     cout << "</pre>" << std::endl;
 }
 
@@ -31,34 +30,25 @@ void DecodeHandler::PopIndent()
     --indent;
 }
 
-std::string DecodeHandler::GetClass(const LogFilters& filters)
+std::string DecodeHandler::GetClass(const LogLevel& level)
 {
-    switch(filters.GetBitfield())
-    {
-        case(flags::EVENT):
-            return "event";
-        case(flags::ERR):
-        case(flags::WARN):
-            return "error";
-        case(flags::APP_HEADER_RX):
-        case(flags::APP_HEADER_TX):
-            return "app-header";
-        case(flags::APP_OBJECT_RX):
-        case(flags::APP_OBJECT_TX):
-            return "app-object-header";
-        case(flags::APP_HEX_RX):
-        case(flags::APP_HEX_TX):
-            return "app-hex";
-        case(flags::LINK_RX):
-        case(flags::LINK_TX):
-        case(flags::LINK_RX_HEX):
-        case(flags::LINK_TX_HEX):
-            return "link";
-        case(flags::TRANSPORT_RX):
-        case(flags::TRANSPORT_TX):
-            return "transport";
-        default:
-            return "unknown";
-    }
+    using namespace opendnp3::flags;
+
+    if (level == EVENT)
+        return "event";
+    else if (level == ERR || level == WARN)
+        return "error";
+    else if (level == APP_HEADER_RX || level == APP_HEADER_TX)
+        return "app-header";
+    else if (level == APP_OBJECT_RX || level == APP_OBJECT_TX)
+        return "app-object-header";
+    else if (level == APP_HEX_RX || level == APP_HEX_TX)
+        return "app-hex";
+    else if (level == LINK_RX || level == LINK_TX || level == LINK_RX_HEX || level == LINK_TX_HEX)
+        return "link";
+    else if (level == TRANSPORT_RX || level == TRANSPORT_TX)
+        return "transport";
+    else
+        return "unknown";
 }
 

--- a/src/DecodeHandler.h
+++ b/src/DecodeHandler.h
@@ -1,12 +1,12 @@
 #ifndef DNP3DECODE_DECODEHANDLER_H
 #define DNP3DECODE_DECODEHANDLER_H
 
-#include <openpal/logging/ILogHandler.h>
-#include <dnp3decode/IDecoderCallbacks.h>
+#include <opendnp3/logging/ILogHandler.h>
+#include <opendnp3/decoder/IDecoderCallbacks.h>
 
 #include <string>
 
-class DecodeHandler final : public openpal::ILogHandler, public opendnp3::IDecoderCallbacks
+class DecodeHandler final : public opendnp3::ILogHandler, public opendnp3::IDecoderCallbacks
 {
 
 public:
@@ -14,10 +14,10 @@ public:
 
 protected:
 
-    static std::string GetClass(const openpal::LogFilters& filters);
+    static std::string GetClass(const opendnp3::LogLevel& level);
 
 
-    virtual void Log( const openpal::LogEntry& entry ) override;
+    virtual void log(opendnp3::ModuleId module, const char* id, opendnp3::LogLevel level, char const* location, char const* message) override;
     virtual void PushIndent() override;
     virtual void PopIndent() override;
 

--- a/src/HexData.cpp
+++ b/src/HexData.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace openpal;
+using namespace opendnp3;
 
 HexData::HexData(const std::string& hex, bool allowBadChars)
     : HexData(RemoveBadCharacters(hex, allowBadChars))
@@ -12,7 +12,7 @@ HexData::HexData(const std::string& hex, bool allowBadChars)
 
 }
 
-HexData::HexData(const std::string& valid) : m_buffer(valid.size()/2)
+HexData::HexData(const std::string& valid) : m_buffer()
 {
     auto NUM_BYTES = valid.size()/2;
 
@@ -29,9 +29,9 @@ HexData::HexData(const std::string& valid) : m_buffer(valid.size()/2)
     }
 }
 
-openpal::RSlice HexData::GetSlice() const
+opendnp3::Buffer HexData::GetSlice() const
 {
-    return m_buffer.ToRSlice();
+    return Buffer(m_buffer.data(), m_buffer.size());
 }
 
 std::string HexData::RemoveBadCharacters(const std::string& hex, bool allowBadChars)

--- a/src/HexData.h
+++ b/src/HexData.h
@@ -2,18 +2,18 @@
 #ifndef HEXDATA_H
 #define HEXDATA_H
 
-#include <openpal/container/RSlice.h>
-#include <openpal/container/Buffer.h>
+#include <opendnp3/util/Buffer.h>
 
 #include <string>
 #include <cstdint>
+#include <array>
 
 class HexData {
 
 public:
     HexData(const std::string& hex, bool allowBadChars);
 
-    openpal::RSlice GetSlice() const;
+    opendnp3::Buffer GetSlice() const;
 
 private:
 
@@ -28,7 +28,7 @@ private:
     static bool IsUpperHexAlpha(char i);
     static bool IsLowerHexAlpha(char i);
 
-    openpal::Buffer m_buffer;
+    std::array<uint8_t, 4096> m_buffer;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,11 @@
 
 
-#include <opendnp3/LogLevels.h>
+#include <opendnp3/logging/LogLevels.h>
 
-#include <dnp3decode/Decoder.h>
+#include <opendnp3/decoder/Decoder.h>
 
-#include <openpal/logging/Logger.h>
-#include <openpal/container/Buffer.h>
-#include <openpal/logging/LogMacros.h>
+#include <opendnp3/logging/Logger.h>
+#include <opendnp3/util/Buffer.h>
 
 #include <cgicc/Cgicc.h>
 #include <cgicc/HTTPHTMLHeader.h>
@@ -18,7 +17,6 @@
 
 using namespace std;
 using namespace cgicc;
-using namespace openpal;
 using namespace opendnp3;
 
 enum class Mode : uint8_t
@@ -48,16 +46,16 @@ int main(int argc, char* argv[])
         const auto MODE = GetMode(cgi);
         const auto HEX = GetHex(cgi);
 
-        const auto FILTERS = ~0 & (~(flags::LINK_RX_HEX | flags::LINK_TX_HEX));
+        //const auto FILTERS = ~0 & (~(flags::LINK_RX_HEX | flags::LINK_TX_HEX));
 
         auto handler = std::make_shared<DecodeHandler>();
-        openpal::Logger logger(handler, "decoder", LogFilters(FILTERS));
+        Logger logger(handler, ModuleId(), "decoder", levels::ALL_COMMS);
 
         Decoder decoder(*handler, logger);
 
         HexData hex(HEX, true);
 
-        FORMAT_HEX_BLOCK(logger, flags::EVENT, hex.GetSlice(), 18, 18);
+        //FORMAT_HEX_BLOCK(logger, flags::EVENT, hex.GetSlice(), 18, 18);
 
         switch(MODE)
         {


### PR DESCRIPTION
This compiles and runs for me against the release branch of opendnp3, but I made some changes I'm not totally pleased with.
1. It looks like the old openpal/container/Buffer.h used to allocate its own storage and the new opendnp3/util/Buffer.h does not, so I replaced m_buffer in HexData.h with a std::array of fixed length 4096. This is probably not the most correct, but it was the shortest path I found to getting it working.
2. LogMacros.h is no longer installed with opendnp3, so the FORMAT_HEX_BLOCK macro no longer displays the original hex of the message to be decoded.
3. CMakeLists.txt in this project isn't very accommodating of having the opendnp3 library installed in non-standard directories. I don't know how to make it better.